### PR TITLE
Fix huge times when using "get match list"

### DIFF
--- a/src/components/MatchEventsTable.tsx
+++ b/src/components/MatchEventsTable.tsx
@@ -81,8 +81,20 @@ const MatchEventsTable: React.FC = () => {
       if (!number) return undefined;
       return teams.find(team => team.number === number)
     }
+
+    rows.sort((prev, curr) => {
+      // Ensure that values without preview times get sorted to the end
+      // Otherwise when loading a match list, you get weird negative values on run matches
+      const prev_time = prev.SHOW_PREVIEW ?? 0
+      const curr_time = curr.SHOW_PREVIEW ?? 0
+      if(prev_time === curr_time) return prev.number-curr.number
+      if(prev_time === 0) return 1
+      if(curr_time === 0) return -1
+      return prev_time - curr_time
+    });
+
     const firstTime = rows[0]?.SHOW_PREVIEW ?? 0
-    let chapters: string[] = rows.sort((a, b) => (a.SHOW_PREVIEW ?? 0) - (b.SHOW_PREVIEW ?? 0)).map(r => {
+    let chapters: string[] = rows.map(r => {
       let blueTeams = `${r.blue1} ${getTeamName(r.blue1)?.name}, ${r.blue2} ${getTeamName(r.blue2)?.name}`
       if (r.blue3)
         blueTeams += `${r.blue3} ${getTeamName(r.blue3)?.name}`
@@ -90,12 +102,15 @@ const MatchEventsTable: React.FC = () => {
       if (r.red3)
         redTeams += `${r.red3} ${getTeamName(r.red3)?.name}`
       let time = ((r.SHOW_PREVIEW ?? 0) - firstTime) / 1000 + offsetTime
-      const hours = Math.floor(time / 3600)
-      time -= hours * 3600
-      const minutes = Math.floor(time / 60)
-      time -= minutes * 60
-      const seconds = Math.floor(time)
-      const timeString = `${hours < 10 ? '0' + hours : hours}:${minutes < 10 ? '0' + minutes : minutes}:${seconds < 10 ? '0' + seconds : seconds}`
+      let timeString = "N/A"
+      if (time>0) {
+        const hours = Math.floor(time / 3600)
+        time -= hours * 3600
+        const minutes = Math.floor(time / 60)
+        time -= minutes * 60
+        const seconds = Math.floor(time)
+        timeString = `${hours < 10 ? '0' + hours : hours}:${minutes < 10 ? '0' + minutes : minutes}:${seconds < 10 ? '0' + seconds : seconds}`
+      }
       return `${timeString} ${r.name} - Blue: ${blueTeams}; Red: ${redTeams}`
     })
     setChapters(['00:00:00 Event Start', ...chapters])

--- a/src/components/MatchEventsTable.tsx
+++ b/src/components/MatchEventsTable.tsx
@@ -103,7 +103,7 @@ const MatchEventsTable: React.FC = () => {
         redTeams += `${r.red3} ${getTeamName(r.red3)?.name}`
       let time = ((r.SHOW_PREVIEW ?? 0) - firstTime) / 1000 + offsetTime
       let timeString = "N/A"
-      if (time>0) {
+      if (time>=0) {
         const hours = Math.floor(time / 3600)
         time -= hours * 3600
         const minutes = Math.floor(time / 60)

--- a/src/components/MatchEventsTable.tsx
+++ b/src/components/MatchEventsTable.tsx
@@ -87,6 +87,7 @@ const MatchEventsTable: React.FC = () => {
       // Otherwise when loading a match list, you get weird negative values on run matches
       const prev_time = prev.SHOW_PREVIEW ?? 0
       const curr_time = curr.SHOW_PREVIEW ?? 0
+      // Use match number as a tie-breaker
       if(prev_time === curr_time) return prev.number-curr.number
       if(prev_time === 0) return 1
       if(curr_time === 0) return -1
@@ -104,6 +105,7 @@ const MatchEventsTable: React.FC = () => {
       let time = ((r.SHOW_PREVIEW ?? 0) - firstTime) / 1000 + offsetTime
       let timeString = "N/A"
       if (time>=0) {
+        // Negative times look bad so show N/A instead
         const hours = Math.floor(time / 3600)
         time -= hours * 3600
         const minutes = Math.floor(time / 60)


### PR DESCRIPTION
When you use the "Get Match List" feature and start running matches, it gives you giant times in your chapters list until you run all the matches. Example:
![image](https://github.com/user-attachments/assets/9cd5d54c-d7fe-46e5-898b-5480bd35aeab)

This PR cleans that up and fixes the associated weird sorting:
![image](https://github.com/user-attachments/assets/3b144c4b-df04-4c0b-8b9f-9e9e1fc106e0)
