### PR TITLE
Use obs stream time

### DIFF
--- a/src/contexts/ObsStudioContext.tsx
+++ b/src/contexts/ObsStudioContext.tsx
@@ -54,6 +54,7 @@ export const ObsStudioProvider: React.FC<ObsStudioProviderProps> = ({ children }
       const hello = await obs.connect(`ws://${obsUrl}:${obsPort}`, obsPassword);
       console.log('Hello message:', hello)
 
+      // Watch for streaming started, and save the time
       obs.on('StreamStateChanged',(data: OBSEventTypes["StreamStateChanged"] ) => {
         if (data.outputState === "OBS_WEBSOCKET_OUTPUT_STARTED"){
           console.log("Stream started at ", Date.now())

--- a/src/contexts/ObsStudioContext.tsx
+++ b/src/contexts/ObsStudioContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, useCallback, ReactNode, useRef, useEffect } from 'react';
 import OBSWebSocket from 'obs-websocket-js';
 import { usePersistentState } from '../helpers/persistant';
+import type {OBSEventTypes} from "obs-websocket-js/dist/types";
 
 type ObsStudioProviderProps = {
   children: ReactNode;
@@ -27,6 +28,7 @@ interface ObsStudioContextData {
   setField1Scene: React.Dispatch<React.SetStateAction<string | undefined>>;
   field2Scene?: string;
   setField2Scene: React.Dispatch<React.SetStateAction<string | undefined>>;
+  startStreamTime: number;
 }
 
 // Create the context
@@ -46,11 +48,18 @@ export const ObsStudioProvider: React.FC<ObsStudioProviderProps> = ({ children }
   const [field1Scene, setField1Scene] = usePersistentState<string | undefined>('Field1_Scene', undefined)
   const [field2Scene, setField2Scene] = usePersistentState<string | undefined>('Field2_Scene', undefined)
   const [error, setError] = useState<string | undefined>(undefined)
-
+  const [startStreamTime, setStartStreamTime] = usePersistentState<number>('Stream_Start', 0);
   const connectToObs = useCallback(async () => {
     try {
       const hello = await obs.connect(`ws://${obsUrl}:${obsPort}`, obsPassword);
       console.log('Hello message:', hello)
+
+      obs.on('StreamStateChanged',(data: OBSEventTypes["StreamStateChanged"] ) => {
+        if (data.outputState === "OBS_WEBSOCKET_OUTPUT_STARTED"){
+          console.log("Stream started at ", Date.now())
+          setStartStreamTime(Date.now())
+        }})
+
       setIsConnected(true);
       setError(undefined)
       // ... additional setup if needed
@@ -69,7 +78,7 @@ export const ObsStudioProvider: React.FC<ObsStudioProviderProps> = ({ children }
         setError(`Unknown Error: ${JSON.stringify(error)}`);
       }
     }
-  }, [obsUrl, obsPort, obsPassword]);
+  }, [obsUrl, obsPort, obsPassword, setStartStreamTime]);
 
   const disconnectFromObs = useCallback(() => {
     obs.disconnect();
@@ -124,7 +133,7 @@ export const ObsStudioProvider: React.FC<ObsStudioProviderProps> = ({ children }
   }
 
   return (
-    <ObsStudioContext.Provider value={{ obsUrl, setObsUrl, obsPort, setObsPort, obsPassword, setObsPassword, isConnected, connectToObs, disconnectFromObs, fetchScenes, switchScenes, field1Scene, field2Scene, setField1Scene, setField2Scene, setActiveField, error }}>
+    <ObsStudioContext.Provider value={{ obsUrl, setObsUrl, obsPort, setObsPort, obsPassword, setObsPassword, isConnected, connectToObs, disconnectFromObs, fetchScenes, switchScenes, field1Scene, field2Scene, setField1Scene, setField2Scene, setActiveField, error, startStreamTime}}>
       {children}
     </ObsStudioContext.Provider>
   );


### PR DESCRIPTION
This allows the tool to detect when the stream is started in OBS, and use that for calculating the first match offset for the chapter markers. This should be useful if events are starting the stream much earlier for things like opening ceremonies. 

It adds in a checkbox below the Offset Time box to enable it.
![image](https://github.com/user-attachments/assets/d6932e8f-d84a-4943-9876-1e01ee36718c)
